### PR TITLE
Change request format from url.values to json

### DIFF
--- a/group_client.go
+++ b/group_client.go
@@ -1,6 +1,8 @@
 package vimeo
 
 import (
+	"encoding/json"
+	"net/http"
 	"net/url"
 	"strconv"
 )
@@ -8,55 +10,65 @@ import (
 // Group client
 type GroupClient struct{}
 
+// Option values for createGroup method.
+type CreateGroupOption struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+func (o CreateGroupOption) GetValues() url.Values {
+	return nil
+}
+func (o CreateGroupOption) GetJSONBytes() ([]byte, error) {
+	return json.Marshal(o)
+}
+
 // Create group
 // GroupOptions is not required
-func (c *GroupClient) CreateGroup(name, description string) (*Group, error) {
-	var values url.Values
-	values.Add("name", name)
-	values.Add("description", description)
-
+func (c *GroupClient) CreateGroup(option *CreateGroupOption) (*Group, error) {
+	var data QueryRequest
+	if option != nil {
+		data = option
+	}
 	group := Group{}
-	err := query("POST", "/groups", values, &group)
+	err := query(http.MethodPost, "/groups", data, &group)
 	return &group, err
 }
 
+// Delete group
 func (c *GroupClient) DeleteGroup(groupID int) error {
-	return query("DELETE", "/groups/"+strconv.Itoa(groupID), nil, nil)
+	return query(http.MethodDelete, "/groups/"+strconv.Itoa(groupID), nil, nil)
 }
 
 // Show own group
 func (c *GroupClient) ShowMyGroup(groupID int) (*Group, error) {
 	group := Group{}
-	err := query("GET", "/me/groups/"+strconv.Itoa(groupID), nil, &group)
+	err := query(http.MethodGet, "/me/groups/"+strconv.Itoa(groupID), nil, &group)
 	return &group, err
 }
 
 // list own groups
 // ListOptions is not required
 func (c *GroupClient) ListMyGroups(option *ListOptions) (*GroupList, error) {
-	var values url.Values
+	var data QueryRequest
 	if option != nil {
-		values = option.createValues()
+		data = option
 	}
 	groups := GroupList{}
-	err := query("GET", "/me/groups", values, &groups)
+	err := query(http.MethodGet, "/me/groups", data, &groups)
 	return &groups, err
 }
 
 func (c *GroupClient) ListAllGroups(option *ListOptions) (*GroupList, error) {
-	var values url.Values
-	if option != nil {
-		values = option.createValues()
-	}
 	groups := GroupList{}
-	err := query("GET", "/groups", values, &groups)
+	err := query(http.MethodGet, "/groups", option, &groups)
 	return &groups, err
 }
 
 func (c *GroupClient) JoinGroup(groupID int) error {
-	return query("PUT", "/me/groups/"+strconv.Itoa(groupID), nil, nil)
+	return query(http.MethodPut, "/me/groups/"+strconv.Itoa(groupID), nil, nil)
 }
 
 func (c *GroupClient) LeaveGroup(groupID int) error {
-	return query("DELETE", "/me/groups/"+strconv.Itoa(groupID), nil, nil)
+	return query(http.MethodDelete, "/me/groups/"+strconv.Itoa(groupID), nil, nil)
 }

--- a/list.go
+++ b/list.go
@@ -55,16 +55,33 @@ const (
 	DirectionDescending = "desc"
 )
 
-// Create url values from list options
-func (o *ListOptions) createValues() url.Values {
+func (o *ListOptions) GetJSONBytes() ([]byte, error) {
+	return nil, nil
+}
+
+func (o *ListOptions) GetValues() url.Values {
 	values := url.Values{}
 	values.Add("page", strconv.Itoa(o.Page))
-	values.Add("per_page", strconv.Itoa(o.PerPage))
-	values.Add("query", o.Query)
-	values.Add("filter", o.Filter)
-	values.Add("filter_embeddable", strconv.FormatBool(o.FilterEmbeddable))
-	values.Add("filter_playable", strconv.FormatBool(o.FilterPlayable))
-	values.Add("sort", o.Sort)
-	values.Add("Direction", o.Direction)
+	if p := o.PerPage; p != 0 {
+		values.Add("per_page", strconv.Itoa(p))
+	}
+	if q := o.Query; q != "" {
+		values.Add("query", q)
+	}
+	if f := o.Filter; f != "" {
+		values.Add("filter", f)
+	}
+	if f := o.FilterEmbeddable; f != false {
+		values.Add("filter_embeddable", strconv.FormatBool(f))
+	}
+	if f := o.FilterPlayable; f != false {
+		values.Add("filter_playable", strconv.FormatBool(f))
+	}
+	if s := o.Sort; s != "" {
+		values.Add("sort", s)
+	}
+	if d := o.Direction; d != "" {
+		values.Add("Direction", d)
+	}
 	return values
 }

--- a/me_client.go
+++ b/me_client.go
@@ -1,13 +1,17 @@
 package vimeo
 
+import (
+	"net/http"
+)
+
 // Me client
 type MeClient struct{}
 
 // View one user
 func (c *MeClient) ShowInfomation() (*Me, error) {
 	user := Me{}
-	err := query("GET", "/me", nil, &user)
-	if err == nil  {
+	err := query(http.MethodGet, "/me", nil, &user)
+	if err == nil {
 		return &user, err
 	}
 	return &user, err

--- a/video.go
+++ b/video.go
@@ -1,6 +1,7 @@
 package vimeo
 
 import "net/url"
+import "encoding/json"
 
 // Video Type Option
 const (
@@ -11,16 +12,17 @@ const (
 
 // Request of [POST] /videos
 type VideoOptions struct {
-	Type        string
-	RedirectURL string
-	Link        string
+	Type        string `json:"type,omitempty"`
+	RedirectURL string `json:"RedirectURL,omitempty"`
+	Link        string `json:"Link,omitempty"`
 }
 
-func (o *VideoOptions) createValues() url.Values {
-	values := url.Values{}
-	values.Add("type", o.Type)
-	values.Add("redirect_url", o.RedirectURL)
-	return values
+func (o *VideoOptions) GetJSONBytes() ([]byte, error) {
+	return json.Marshal(o)
+}
+
+func (o *VideoOptions) GetValues() url.Values {
+	return nil
 }
 
 // Response of [GET] /me/videos/{video_id}

--- a/video_client.go
+++ b/video_client.go
@@ -1,7 +1,7 @@
 package vimeo
 
 import (
-	"net/url"
+	"net/http"
 	"strconv"
 )
 
@@ -11,30 +11,30 @@ type VideoClient struct{}
 // Create video
 // VideoOptions is not required
 func (c *VideoClient) CreateVideo(option *VideoOptions) (*Video, error) {
-	var values url.Values
+	var data QueryRequest
 	if option != nil {
-		values = option.createValues()
+		data = option
 	}
 	video := Video{}
-	err := query("POST", "/me/videos", values, &video)
+	err := query(http.MethodPost, "/me/videos", data, &video)
 	return &video, err
 }
 
 // Show own video
 func (c *VideoClient) ShowMyVideo(videoID int) (*Video, error) {
 	video := Video{}
-	err := query("GET", "/me/videos/"+strconv.Itoa(videoID), nil, &video)
+	err := query(http.MethodGet, "/me/videos/"+strconv.Itoa(videoID), nil, &video)
 	return &video, err
 }
 
 // list own videos
 // ListOptions is not required
 func (c *VideoClient) ListMyVideos(option *ListOptions) (*VideoList, error) {
-	var values url.Values
+	var data QueryRequest
 	if option != nil {
-		values = option.createValues()
+		data = option
 	}
 	videos := VideoList{}
-	err := query("GET", "/me/videos", values, &videos)
+	err := query(http.MethodGet, "/me/videos", data, &videos)
 	return &videos, err
 }


### PR DESCRIPTION
It is so hard to check null value in request values.
If you define request formant by JSON, you can use `omitempty` option.
Null check can be avoided, if you use this option.
